### PR TITLE
haskell: GHC 9.8.2

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -2,14 +2,14 @@ Maintainers: Albert Krewinkel <albert+docker@tarleb.com> (@tarleb),
              Andrei Dziahel <develop7@develop7.info> (@develop7)
 GitRepo: https://github.com/haskell/docker-haskell
 
-Tags: 9.8.1-buster, 9.8-buster, 9-buster, buster, 9.8.1, 9.8, 9, latest
+Tags: 9.8.2-buster, 9.8-buster, 9-buster, buster, 9.8.2, 9.8, 9, latest
 Architectures: amd64, arm64v8
-GitCommit: 663780ca62e72279d9a684e44fcca33f894fcfbf
+GitCommit: 918d184d9a5ffb37aeefa579a980a4b13d9aafc2
 Directory: 9.8/buster
 
-Tags: 9.8.1-slim-buster, 9.8-slim-buster, 9-slim-buster, slim-buster, 9.8.1-slim, 9.8-slim, 9-slim, slim
+Tags: 9.8.2-slim-buster, 9.8-slim-buster, 9-slim-buster, slim-buster, 9.8.2-slim, 9.8-slim, 9-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 663780ca62e72279d9a684e44fcca33f894fcfbf
+GitCommit: 918d184d9a5ffb37aeefa579a980a4b13d9aafc2
 Directory: 9.8/slim-buster
 
 Tags: 9.6.4-buster, 9.6-buster, 9.6.4, 9.6


### PR DESCRIPTION
Upgrade Haskell 9.8 images to GHC 9.8.2